### PR TITLE
Fix handling version numbers in an array

### DIFF
--- a/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psm1
+++ b/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psm1
@@ -41,6 +41,9 @@ function TestVersion {
     param ( [string[]]$versions )
     $allowedVersions = Get-AvailableVersion
     foreach ($version in $versions) {
+        if ( $version -notmatch "\." ) {
+            $version = "${version}.0"
+        }
         if ( $allowedVersions -notcontains $version ) {
             throw ("'$version' not in: " + ( $allowedVersions -join ", "))
         }
@@ -128,6 +131,7 @@ function Get-WhatsNew {
         $Version = '{0}.{1}' -f $PSVersionTable.PSVersion.Major, $PSVersionTable.PSVersion.Minor
     }
 
+    $Version = $Version | foreach-object { if ( $_ -notmatch "\." ) { "${_}.0" } else { $_ } }
     $versions = Get-AvailableVersion -uriHashtable | Where-Object {$_.version -in $Version}
 
     # Resolve parameter set

--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,14 @@ if ($publish) {
 }
 
 if ( $test ) {
+    if ( ! $publish ) {
+        ./build.ps1 -publish
+    }
     # run tests
+    $psExe = (get-process -id $PID).MainModule.filename
+    $testCommand = "import-module $PSScriptRoot/out/${moduleName}; Set-Location $PSScriptRoot/test; Invoke-Pester"
+    $psArgs = "-noprofile","-noninteractive","-command",$testCommand
+    & $psExe $psArgs
 }
 
 if ( $package ) {

--- a/test/WhatsNew.Tests.ps1
+++ b/test/WhatsNew.Tests.ps1
@@ -1,0 +1,34 @@
+Describe "General tests for 'Get-WhatsNew'" {
+    BeforeAll {
+        $files = "What-s-New-in-PowerShell-70.md",
+            "What-s-New-in-PowerShell-71.md",
+            "What-s-New-in-PowerShell-72.md",
+            "What-s-New-in-PowerShell-73.md",
+            "What-s-New-in-PowerShell-Core-60.md",
+            "What-s-New-in-PowerShell-Core-61.md",
+            "What-s-New-in-PowerShell-Core-62.md",
+            "What-s-New-in-Windows-PowerShell-50.md"
+        $header2hash = @{}
+        foreach ( $file in $files ) {
+            $fileNumber = $file -replace ".*(\d\d).md",'$1'
+            $key = "File${fileNumber}"
+            $header2hash[$key] = select-string -raw "^## " "../Microsoft.PowerShell.WhatsNew/relnotes/$file"
+        }
+    }
+    It "Handles Single Version" {
+        $observed = Get-WhatsNew -version 7.2 | Select-String -Raw "^## "
+        $observed | Should -Be $header2hash["File72"]
+    }
+
+    It "Handles Single Version ending in '0'" {
+        $observed = Get-WhatsNew -version 7.0 | Select-String -Raw "^## "
+        $observed | Should -Be $header2hash["File70"]
+    }
+
+    It "Handles multiple versions" {
+        $observed = Get-WhatsNew -version 7.0,6.0,5.1 | Select-String -Raw "^## "
+        $collection = @( $header2hash["File70"]; $header2hash["File60"]; $header2hash["File50"])
+        $observed | Should -Be $collection
+    }
+}
+

--- a/test/WhatsNew.Tests.ps1
+++ b/test/WhatsNew.Tests.ps1
@@ -30,5 +30,10 @@ Describe "General tests for 'Get-WhatsNew'" {
         $collection = @( $header2hash["File70"]; $header2hash["File60"]; $header2hash["File50"])
         $observed | Should -Be $collection
     }
+
+    It "Converts a version missing the period to version.0" {
+        $observed = Get-WhatsNew -version 7 | Select-String -Raw "^## "
+        $observed | Should -Be $header2hash["File70"]
+    }
 }
 


### PR DESCRIPTION
also enable user to type `Get-WhatsNew -version 6`
add some tests