### PR TITLE
Move clean block to the top

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -4,6 +4,11 @@ $psd = Import-PowerShellDataFile "$PSScriptRoot/${moduleName}/${moduleName}.psd1
 $moduleVersion = $psd.ModuleVersion
 $moduleDeploymentDir = "${PSScriptRoot}/out/${moduleName}/${moduleVersion}"
 
+if ( $clean ) {
+    $null = Remove-Item "${PSScriptRoot}/out" -Recurse -Force
+    $null = Remove-Item "$PsScriptRoot/*.nupkg" -Force
+}
+
 if ($publish) {
     # create directory with version
     # copy files to that location
@@ -37,9 +42,4 @@ if ( $package ) {
         Unregister-PSRepository -Name $repoName
     }
 
-}
-
-if ( $clean ) {
-    $null = Remove-Item "${PSScriptRoot}/out" -Recurse -Force
-    $null = Remove-Item "$PsScriptRoot/*.nupkg" -Force
 }


### PR DESCRIPTION
Moving clean block to the top allows us to clean before we build / publish

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update build.ps1 to support clean and publish switches together

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
