### PR TITLE
Update release notes for 7.4-preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Get-WhatsNew
 
+## v0.5.1
+
+- Updated the 7.3 release notes
+- Added the release notes for 7.4-preview.1
+
 ## v0.5.0
 
 - Updated release notes files for 7.3 GA release

--- a/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psd1
+++ b/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psd1
@@ -1,7 +1,7 @@
 # Module manifest for module 'Microsoft.PowerShell.WhatsNew'
 @{
 RootModule = 'Microsoft.PowerShell.WhatsNew.psm1'
-ModuleVersion = '0.5.0'
+ModuleVersion = '0.5.1'
 GUID = 'e49f73fd-7419-4639-84d7-159ebc32645e'
 Author = 'sewhee@microsoft.com'
 CompanyName = 'Microsoft'
@@ -20,6 +20,7 @@ The cmdlet can display release notes for the following versions of PowerShell
 - PowerShell 7.1
 - PowerShell 7.2
 - PowerShell 7.3
+- PowerShell 7.4 (preview)
 
 By default, the cmdlet shows all of the release notes for a version. You can also limit it to
 display a single random section of the release notes. This can be used as a "Message of the Day".
@@ -34,6 +35,7 @@ FileList = 'relnotes/What-s-New-in-PowerShell-70.md',
            'relnotes/What-s-New-in-PowerShell-71.md',
            'relnotes/What-s-New-in-PowerShell-72.md',
            'relnotes/What-s-New-in-PowerShell-73.md',
+           'relnotes/What-s-New-in-PowerShell-74.md',
            'relnotes/What-s-New-in-PowerShell-Core-60.md',
            'relnotes/What-s-New-in-PowerShell-Core-61.md',
            'relnotes/What-s-New-in-PowerShell-Core-62.md',

--- a/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psm1
+++ b/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psm1
@@ -68,6 +68,7 @@ function TestVersion {
     - PowerShell 7.1
     - PowerShell 7.2
     - PowerShell 7.3
+    - PowerShell 7.4 (preview)
 
     By default, the cmdlet shows all of the release notes for a version. You can also limit it to
     display a single random section of the release notes. This can be used as a "Message of the Day".

--- a/Microsoft.PowerShell.WhatsNew/relnotes/What-s-New-in-PowerShell-73.md
+++ b/Microsoft.PowerShell.WhatsNew/relnotes/What-s-New-in-PowerShell-73.md
@@ -1,7 +1,7 @@
 ---
 title: What's New in PowerShell 7.3
 description: New features and changes released in PowerShell 7.3
-ms.date: 11/28/2022
+ms.date: 12/14/2022
 ---
 
 # What's New in PowerShell 7.3
@@ -111,24 +111,37 @@ For a complete list of changes, see the [Change Log][11] in the GitHub repositor
 
 ## Experimental Features
 
+In PowerShell 7.3, following experimental features became mainstream:
+
+- [PSAnsiRenderingFileInfo][13] - This feature adds the `$PSStyle.FileInfo` member and enables
+  coloring of specific file types.
+- [PSCleanBlock][04] - Adds `clean` block to script block as a peer to `begin`, `process`, and `end`
+  to allow easy resource cleanup.
+- [PSAMSIMethodInvocationLogging][02] - Extends the data sent to AMSI for inspection to include all
+  invocations of .NET method members.
+- [PSNativeCommandArgumentPassing][08] - PowerShell now uses the **ArgumentList** property of the
+  **StartProcessInfo** object rather than the old mechanism of reconstructing a string when invoking
+  a native executable.
+
+  PowerShell 7.3.1 adds `sqlcmd.exe` to the list of native commands in Windows that use the `Legacy`
+  style of argument passing.
+- [PSExec][05] - Adds the new `Switch-Process` cmdlet (alias `exec`) to provide `exec` compatibility
+  for non-Windows systems.
+
+  PowerShell 7.3.1 changed the `exec` alias to a function that wraps `Switch-Process`. The function
+  allows you to pass parameters to the native command that might have erroneously bound to the
+  **WithCommand** parameter.
+
 PowerShell 7.3 introduces the following experimental features:
 
-- [PSExec][05] - Adds the new `Switch-Process` cmdlet (alias `exec`) to provide `exec`
-  compatibility for non-Windows systems. In PowerShell 7.3-preview.8, this feature became
-  mainstream.
-- [PSCleanBlock][04] - Adds `clean` block to script block as a peer to `begin`, `process`,
-  and `end` to allow easy resource cleanup. In PowerShell 7.3-preview.8, this feature became
-  mainstream.
-- [PSStrictModeAssignment][07] - Adds the **StrictMode** parameter to `Invoke-Command` to
-  allow specifying strict mode when invoking command locally. In PowerShell 7.3-preview.8, this
-  feature was removed.
 - [PSNativeCommandErrorActionPreference][06] - Adds the
   `$PSNativeCommandUseErrorActionPreference` variable to enable errors produced by native commands
   to be PowerShell errors.
-- [PSAMSIMethodInvocationLogging][02] - Extends the data sent to AMSI for inspection to
-  include all invocations of .NET method members. In PowerShell 7.3-preview.8, this feature became
-  mainstream.
-- Remove [PSNativePSPathResolution][03] experimental feature.
+
+PowerShell 7.3 removed the following experimental features:
+
+- [PSNativePSPathResolution][03] experimental feature is no longer supported.
+- [PSStrictModeAssignment][07] experimental feature is no longer supported.
 
 For more information about the Experimental Features, see [Using Experimental Features][01].
 
@@ -141,6 +154,8 @@ For more information about the Experimental Features, see [Using Experimental Fe
 [05]: ../learn/experimental-features.md#psexec
 [06]: ../learn/experimental-features.md#psnativecommanderroractionpreference
 [07]: ../learn/experimental-features.md#psstrictmodeassignment
+[08]: ../learn/experimental-features.md#psnativecommandargumentpassing
+[13]: ../learn/experimental-features.md#psansirenderingfileinfo
 [09]: https://github.com/dotnet/runtime/issues/66746
 [10]: https://github.com/PowerShell/PowerShell/issues/17018
 [11]: https://github.com/PowerShell/PowerShell/releases/tag/v7.3.0

--- a/Microsoft.PowerShell.WhatsNew/relnotes/What-s-New-in-PowerShell-74.md
+++ b/Microsoft.PowerShell.WhatsNew/relnotes/What-s-New-in-PowerShell-74.md
@@ -1,0 +1,115 @@
+---
+title: What's New in PowerShell 7.4 (preview)
+description: New features and changes released in PowerShell 7.4 (preview)
+ms.date: 01/05/2023
+---
+
+# What's New in PowerShell 7.4 (preview)
+
+PowerShell 7.4-preview.1 includes the following features, updates, and breaking changes.
+
+For a complete list of changes, see the [Change Log][07] in the GitHub repository.
+
+## Breaking changes
+
+- Snap packages aren't available for this release
+- Nano server docker images aren't available for this release
+
+## Tab completion improvements
+
+- Fix issue when completing the first command in a script with an empty array expression
+  ([[#18355][18355]]) (Thanks @MartinGC94!)
+- Fix positional argument completion ([#17796][17796]) (Thanks @MartinGC94!)
+- Improve type inference of hashtable keys ([#17907][17907]) (Thanks @MartinGC94!)
+- Fix type inference error for empty return statements ([#18351][18351]) (Thanks @MartinGC94!)
+- Improve enumeration of inferred types in pipeline ([#17799][17799]) (Thanks @MartinGC94!)
+- Fix member completion in attribute argument ([#17902][17902]) (Thanks @MartinGC94!)
+- Improve pseudo binding for dynamic parameters ([#18030][18030]) (Thanks @MartinGC94!)
+- Add completion for values in comparisons when comparing Enums ([#17654][17654]) (Thanks
+  @MartinGC94!)
+
+## Cmdlet and engine improvements
+
+Update to Web cmdlets
+
+- Web cmdlets get **Retry-After** interval from response headers if the status code is 429
+  ([#18717][18717]) (Thanks @CarloToso!)
+- Web cmdlets set default charset encoding to UTF8 ([#18219][18219]) (Thanks @CarloToso!)
+
+Other cmdlets
+
+- `Update-Help` now reports an error when using implicit culture on non-US systems.
+  ([#17780][17780]) (Thanks @dkaszews!)
+- Add **Confirm** and **WhatIf** parameters to `Stop-Transcript`([#18731][18731]) (Thanks
+  @JohnLBevan!)
+- Add **FuzzyMinimumDistance** parameter to `Get-Command` ([#18261][18261])
+
+Updates to `$PSStyle`
+
+- Adds **Dim** and **DimOff** properties ([#18653][18653])
+- Added static methods to the **PSStyle** class that map foreground and background **ConsoleColor**
+  values to ANSI escape sequences ([#17938][17938])
+- New formatting properties added by experimental features
+
+Other Engine updates
+
+- Make PowerShell class not affiliate with Runspace when declaring the `NoRunspaceAffinity`
+  attribute ([#18138][18138])
+- Add the `ValidateNotNullOrWhiteSpace` attribute ([#17191][17191]) (Thanks @wmentha!)
+- Add `sqlcmd` to the list for legacy argument passing ([#18559][18559])
+- Add the function `cd~` ([#18308][18308]) (Thanks @GigaScratch!)
+
+## Experimental Features
+
+PowerShell 7.4 introduces the following experimental features:
+
+- [PSCustomTableHeaderLabelDecoration][03] - Add formatting differentiation for table header labels
+  that aren't property members.
+  - This feature also adds the **CustomTableHeaderLabel** property to `$PSStyle.Formatting` that
+    allows you to change the formatting of the header label.
+- [PSFeedbackProvider][04] - Replaces the hard-coded suggestion framework with an extensible
+  feedback provider.
+  - This feature also adds the **FeedbackProvider** and **FeedbackText** properties to
+    `$PSStyle.Formatting` that allow you to change the formatting of feedback messages.
+- [PSModuleAutoLoadSkipOfflineFiles][05] - Module discovery now skips over files that are marked by
+  cloud providers as not fully on disk.
+
+PowerShell 7.4 changed the following experimental features:
+
+- [PSNativeCommandErrorActionPreference][06] - `$PSNativeCommandUseErrorActionPreference` is set to
+  `$true` when feature is enabled ([#18695][18695])
+- [PSCommandNotFoundSuggestion][02] - This feature now uses an extensible feedback provider rather
+  than hard-coded suggestions
+
+For more information about the Experimental Features, see [Using Experimental Features][01].
+
+<!-- end of content -->
+<!-- reference links -->
+
+[01]: ../learn/experimental-features.md
+[02]: /powershell/scripting/learn/experimental-features#pscommandnotfoundsuggestion
+[03]: /powershell/scripting/learn/experimental-features#pscustomtableheaderlabeldecoration
+[04]: /powershell/scripting/learn/experimental-features#psfeedbackprovider
+[05]: /powershell/scripting/learn/experimental-features#psmoduleautoloadskipofflinefiles
+[06]: /powershell/scripting/learn/experimental-features#psnativecommanderroractionpreference
+[07]: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/preview.md
+[17191]: https://github.com/PowerShell/PowerShell/pull/17191
+[17654]: https://github.com/PowerShell/PowerShell/pull/17654
+[17780]: https://github.com/PowerShell/PowerShell/pull/17780
+[17796]: https://github.com/PowerShell/PowerShell/pull/17796
+[17799]: https://github.com/PowerShell/PowerShell/pull/17799
+[17902]: https://github.com/PowerShell/PowerShell/pull/17902
+[17907]: https://github.com/PowerShell/PowerShell/pull/17907
+[17938]: https://github.com/PowerShell/PowerShell/pull/17938
+[18030]: https://github.com/PowerShell/PowerShell/pull/18030
+[18138]: https://github.com/PowerShell/PowerShell/pull/18138
+[18219]: https://github.com/PowerShell/PowerShell/pull/18219
+[18261]: https://github.com/PowerShell/PowerShell/pull/18261
+[18308]: https://github.com/PowerShell/PowerShell/pull/18308
+[18351]: https://github.com/PowerShell/PowerShell/pull/18351
+[18355]: https://github.com/PowerShell/PowerShell/pull/18355
+[18559]: https://github.com/PowerShell/PowerShell/pull/18559
+[18653]: https://github.com/PowerShell/PowerShell/pull/18653
+[18695]: https://github.com/PowerShell/PowerShell/pull/18695
+[18717]: https://github.com/PowerShell/PowerShell/pull/18717
+[18731]: https://github.com/PowerShell/PowerShell/pull/18731

--- a/build.ps1
+++ b/build.ps1
@@ -36,7 +36,7 @@ if ( $package ) {
     $repoName = [Guid]::NewGuid().ToString("N")
     try {
         Register-PSRepository -Name $repoName -SourceLocation $PSScriptRoot
-        Publish-Module -Path "$PsScriptRoot/${moduleName}" -Repository $repoName
+        Publish-Module -Path $moduleDeploymentDir -Repository $repoName
     }
     finally {
         Unregister-PSRepository -Name $repoName

--- a/test/WhatsNew.Tests.ps1
+++ b/test/WhatsNew.Tests.ps1
@@ -4,6 +4,7 @@ Describe "General tests for 'Get-WhatsNew'" {
             "What-s-New-in-PowerShell-71.md",
             "What-s-New-in-PowerShell-72.md",
             "What-s-New-in-PowerShell-73.md",
+            "What-s-New-in-PowerShell-74.md",
             "What-s-New-in-PowerShell-Core-60.md",
             "What-s-New-in-PowerShell-Core-61.md",
             "What-s-New-in-PowerShell-Core-62.md",
@@ -16,8 +17,8 @@ Describe "General tests for 'Get-WhatsNew'" {
         }
     }
     It "Handles Single Version" {
-        $observed = (Get-WhatsNew -version 7.2 | Select-String "^## ").Line
-        $observed | Should -Be $header2hash["File72"]
+        $observed = (Get-WhatsNew -version 7.4 | Select-String "^## ").Line
+        $observed | Should -Be $header2hash["File74"]
     }
 
     It "Handles Single Version ending in '0'" {


### PR DESCRIPTION
# PR Summary

This PR includes the following changes:
- Adds release notes for PowerShell 7.4-preview.1
- Syncs changes to the 7.3 release notes from the docs repository
- Tests updated to include 7.4
- Module version changed to 0.5.1
- Changelog and docs updated