### PR TITLE
Remove preview flag for 7.4

### DIFF
--- a/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psm1
+++ b/Microsoft.PowerShell.WhatsNew/Microsoft.PowerShell.WhatsNew.psm1
@@ -68,7 +68,7 @@ function TestVersion {
     - PowerShell 7.1
     - PowerShell 7.2
     - PowerShell 7.3
-    - PowerShell 7.4 (preview)
+    - PowerShell 7.4
 
     By default, the cmdlet shows all of the release notes for a version. You can also limit it to
     display a single random section of the release notes. This can be used as a "Message of the Day".


### PR DESCRIPTION
# PR Summary

Fix incorrect "preview" flag in the Get-WhatsNew CmdLet help.

## PR Context

In #38, almost all "preview" flags for PowerShell 7.4 have been removed.
But in the help text in Get-WhatsNew CmdLet, the "preview" flags remain (its just a slight mistake I guess).